### PR TITLE
Support the DHCP domain name option

### DIFF
--- a/lib/dhcp.js
+++ b/lib/dhcp.js
@@ -351,6 +351,7 @@ function createDHCPreply(packet, data) {
                     // string options
                     case 150: // grub menu
                     case 67:  // boot filename
+                    case 15:  // domain name
                     case 12:  // hostname
                         pkt.options[opt] = [];
                         for (var j = 0; j < value.length; j++) {

--- a/lib/dhcpd.js
+++ b/lib/dhcpd.js
@@ -201,6 +201,10 @@ DHCPD.prototype.buildPacketOpts = function (packet, params, log) {
         packetOpts['options']['3'] = this.config.defaultGateway;
     }
 
+    if (this.config.dnsDomain) {
+        packetOpts['options']['15'] = this.config.dnsDomain;
+    }
+
     if (packet.options[77]) {
         var userClass = new Buffer(packet.options[77]).toString();
         if (userClass === 'gPXE' || userClass === 'iPXE') {


### PR DESCRIPTION
Needed for the authentication solution that we are using for compute node access, this change provides a correct DNS search domain at boot time.
