### PR TITLE
TRITON-1969 booter needs to offer boot module support

### DIFF
--- a/lib/boot-files.js
+++ b/lib/boot-files.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 /*
@@ -13,10 +13,13 @@
  */
 
 var fmt = require('util').format;
+
+const bootModuleFiles = require('./boot-module-files');
 var mod_menulst = require('./menulst');
 var mod_bootparams = require('./bootparams');
 var mod_find = require('./find');
 var mod_net_file = require('./net-file');
+
 var mod_vasync = require('vasync');
 
 
@@ -103,10 +106,24 @@ function writeBootFiles(opts, callback) {
 
         // Write out networking.json file.
         function _bootTimeFile(arg, cb) {
-            mod_net_file.write(arg, function (err) {
+            mod_net_file.write(arg, function (_err) {
                 // Don't let this hold up booting - we can always fall back to
                 // parameters
                 return cb();
+            });
+        },
+
+        // Write out any suplemental boot module files we need for this CN
+        function _bootTimeModulesFs(arg, cb) {
+            // Skip if no suplemental boot file modules
+            if (!arg.bootParams.boot_modules) {
+                cb();
+                return;
+            }
+            bootModuleFiles.write(arg, function (_err) {
+                // Don't let this hold up booting - we can always fall back to
+                // parameters
+                cb();
             });
         },
 

--- a/lib/boot-files.js
+++ b/lib/boot-files.js
@@ -120,11 +120,7 @@ function writeBootFiles(opts, callback) {
                 cb();
                 return;
             }
-            bootModuleFiles.write(arg, function (_err) {
-                // Don't let this hold up booting - we can always fall back to
-                // parameters
-                cb();
-            });
+            bootModuleFiles.write(arg, cb);
         },
 
         // Make sure networking.json file is in the bootFsDir.

--- a/lib/boot-module-files.js
+++ b/lib/boot-module-files.js
@@ -1,0 +1,122 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright 2020 Joyent, Inc.
+ */
+
+/*
+ * Read / write boot-time module files
+ */
+
+const fs = require('fs');
+const path = require('path');
+const util = require('util');
+
+const assert = require('assert-plus');
+const mkdirp = require('mkdirp');
+const vasync = require('vasync');
+
+function generateBootModuleFile(opts, cb) {
+    assert.object(opts, 'opts');
+    assert.object(opts.log, 'opts.log');
+    assert.object(opts.module, 'opts.module');
+    assert.string(opts.module.content, 'opts.module.content');
+    assert.optionalString(opts.module.type, 'opts.module.type');
+
+    if (opts.module.type !== 'base64') {
+        cb(new Error(util.format(
+            'Unsupported type %s for module %s',
+            opts.module.type, opts.module.path)));
+        return;
+    }
+
+    cb(null, Buffer.from(
+        opts.module.content, 'base64').toString('ascii'));
+}
+
+function writeBootModuleFiles(opts, cb) {
+    assert.object(opts, 'opts');
+    assert.string(opts.bootFsDir, 'opts.bootFsDir');
+    assert.object(opts.log, 'opts.log');
+    assert.object(opts.bootParams, 'opts.bootParams');
+    assert.func(cb, 'cb');
+
+    const bootModules = opts.bootParams.boot_modules;
+
+    if (!bootModules || !bootModules.length) {
+        opts.log.warn('No boot modules: returning');
+        cb();
+        return;
+    }
+
+    vasync.pipeline({ funcs: [
+        function _mkdir(_, next) {
+            mkdirp(opts.bootFsDir, function (err) {
+                if (err) {
+                    if (err.code === 'EEXIST') {
+                        next();
+                        return;
+                    }
+
+                    opts.log.error(err, 'Error creating directory "%s"',
+                        opts.bootFsDir);
+                }
+
+                next(err);
+            });
+        },
+        function _writeFiles(_, next) {
+            vasync.forEachParallel({
+                func: function _generateBootModuleFile(arg, nextMod) {
+                    generateBootModuleFile({
+                        module: arg,
+                        log: opts.log,
+                        bootFsDir: opts.bootFsDir
+                    }, function genModCb(modErr, moduleContents) {
+                        if (modErr) {
+                            nextMod(modErr);
+                            return;
+                        }
+                        const file = path.resolve(opts.bootFsDir, arg.path);
+                        const filePath = path.dirname(file);
+                        opts.log.info({
+                            path: filePath, file: file
+                        }, 'FILEANDPATH');
+
+                        mkdirp(filePath, function (err) {
+                            if (err && err.code !== 'EEXIST') {
+                                opts.log.error(err,
+                                    'Error creating directory "%s"',
+                                    filePath);
+                                nextMod(err);
+                                return;
+                            }
+
+                            fs.writeFile(file, moduleContents, function (fErr) {
+                                if (fErr) {
+                                    opts.log.error(
+                                        fErr, 'Error writing "%s"', file);
+                                    nextMod(fErr);
+                                    return;
+                                }
+
+                                opts.log.debug('wrote "%s"', file);
+                                nextMod();
+                            });
+                        });
+                    });
+                },
+                inputs: bootModules
+            }, next);
+        }
+    ]}, cb);
+}
+
+module.exports = {
+    generate: generateBootModuleFile,
+    write: writeBootModuleFiles
+};

--- a/lib/boot-module-files.js
+++ b/lib/boot-module-files.js
@@ -83,9 +83,6 @@ function writeBootModuleFiles(opts, cb) {
                         }
                         const file = path.resolve(opts.bootFsDir, arg.path);
                         const filePath = path.dirname(file);
-                        opts.log.info({
-                            path: filePath, file: file
-                        }, 'FILEANDPATH');
 
                         mkdirp(filePath, function (err) {
                             if (err && err.code !== 'EEXIST') {

--- a/lib/boot-module-files.js
+++ b/lib/boot-module-files.js
@@ -22,10 +22,10 @@ const vasync = require('vasync');
 
 function generateBootModuleFile(opts, cb) {
     assert.object(opts, 'opts');
-    assert.object(opts.log, 'opts.log');
     assert.object(opts.module, 'opts.module');
     assert.string(opts.module.content, 'opts.module.content');
     assert.optionalString(opts.module.type, 'opts.module.type');
+    assert.func(cb, 'cb');
 
     if (opts.module.type !== 'base64') {
         cb(new Error(util.format(
@@ -35,7 +35,7 @@ function generateBootModuleFile(opts, cb) {
     }
 
     cb(null, Buffer.from(
-        opts.module.content, 'base64').toString('ascii'));
+        opts.module.content, 'base64').toString('binary'));
 }
 
 function writeBootModuleFiles(opts, cb) {

--- a/lib/bootparams.js
+++ b/lib/bootparams.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2018, Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 /*
@@ -13,7 +13,6 @@
  */
 
 var assert = require('assert-plus');
-var fs = require('fs');
 var jsprim = require('jsprim');
 var mod_clients = require('./clients');
 var mod_json = require('./json-file');
@@ -73,7 +72,7 @@ function getFromCache(opts, callback) {
         log.debug(data, 'getFromCache: got cached params from "%s/%s.json"',
             dir, mac);
 
-        return callback(null, { bootParams: data });
+        callback(null, { bootParams: data });
     });
 }
 
@@ -197,7 +196,7 @@ function getBootParams(opts, callback) {
             function _getNic(fArg, cb) {
                 napi.getNic(mac, function (err, res) {
                     if (err) {
-                        if (err.statusCode == 404) {
+                        if (err.statusCode === 404) {
                             log.debug('Did not find nic "%s" in NAPI', mac);
                             return cb();
                         }
@@ -246,7 +245,8 @@ function getBootParams(opts, callback) {
             // If the nic exists in NAPI but it doesn't have an IP, give it one
             function _provisionIP(fArg, cb) {
                 if (fArg.bootNic === null || fArg.bootNic.ip) {
-                    return cb();
+                    cb();
+                    return;
                 }
 
                 assert(fArg.bootNic.network_uuid === undefined,
@@ -277,7 +277,8 @@ function getBootParams(opts, callback) {
             // network (or pool), which will give it an IP
             function _createNic(fArg, cb) {
                 if (fArg.bootNic !== null) {
-                    return cb();
+                    cb();
+                    return;
                 }
 
                 var postParams = {
@@ -313,14 +314,15 @@ function getBootParams(opts, callback) {
             function _bootParams(fArg, cb) {
                 uuid = fArg.bootNic.belongs_to_uuid;
                 fArg.cn_uuid = fArg.bootNic.belongs_to_uuid;
-                if (uuid == adminUuid) {
+                if (uuid === adminUuid) {
                     uuid = 'default';
-                    return cb();
+                    cb();
+                    return;
                 }
 
                 cnapi.getBootParams(uuid, function (err, res) {
                     if (err) {
-                        if (err.statusCode == 404) {
+                        if (err.statusCode === 404) {
                             log.warn('Did not find bootparams for "%s" in '
                                 + 'CNAPI: continuing anyway', uuid);
                             uuid = 'default';
@@ -351,9 +353,10 @@ function getBootParams(opts, callback) {
             // is set to the admin UUID.  This means that the nic doesn't
             // belong to a server that has successfully updated NAPI with its
             // sysinfo
-            function _defaultBootParams(fArg, cb) {
-                if (uuid != 'default') {
-                    return cb();
+            function _defaultBootParams(_fArg, cb) {
+                if (uuid !== 'default') {
+                    cb();
+                    return;
                 }
 
                 cnapi.getBootParams(uuid, function (err, res) {
@@ -385,19 +388,21 @@ function getBootParams(opts, callback) {
         }
 
         if (err) {
-            return getFromCache({
+            getFromCache({
                 dir: cacheDir,
                 err: err,
                 log: log,
                 mac: mac
             }, callback);
+            return;
         }
 
         if (!vArg.bootNic.ip || !vArg.bootNic.netmask) {
             var nicErr = new Error('Error: boot nic has no IP or netmask');
             log.error({ err: nicErr, nic: vArg.bootNic },
                 'Error with boot nic from NAPI');
-            return callback(nicErr);
+            callback(nicErr);
+            return;
         }
 
         var adminNic = vArg.bootNic;
@@ -464,7 +469,7 @@ function getBootParams(opts, callback) {
                  * a network that is in the admin network pool.  We do the same
                  * below for aggrs.
                  */
-                if (tag == 'admin_nic' ||
+                if (tag === 'admin_nic' ||
                     poolContainsTag(adminPool, nictag)) {
                         if (adminFound) {
                             log.warn({orig_admin: adminNic, new_admin: nic},
@@ -519,17 +524,18 @@ function getBootParams(opts, callback) {
 
         log.info({ params: params, mac: mac }, 'Boot params generated');
 
-        return mod_json.write({
+        mod_json.write({
             dir: cacheDir,
             log: log,
             name: fmt('%s.json', mac),
             payload: params
         }, function (storeErr) {
             if (storeErr) {
-                return callback(storeErr);
+                callback(storeErr);
+                return;
             }
 
-            return callback(null, {
+            callback(null, {
                 adminNic: adminNic,
                 aggrs: vArg.aggrs,
                 bootParams: params,

--- a/lib/net-file.js
+++ b/lib/net-file.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 /*
@@ -40,7 +40,7 @@ function isUnderlayNic(opts, nic) {
     if (opts.overlay.enabled && opts.overlay.portolan &&
             nic.underlay &&
             opts.overlay.underlayNicTag &&
-            opts.overlay.underlayNicTag == nic.nic_tag) {
+            opts.overlay.underlayNicTag === nic.nic_tag) {
         return true;
     }
 
@@ -201,11 +201,10 @@ function writeNetConfFile(opts, callback) {
 
     for (var n in conf.nictags) {
         nictag = conf.nictags[n].name;
-        if (nictag == 'admin' ||
+        if (nictag === 'admin' ||
             (adminPool &&
             adminPool.hasOwnProperty('nic_tags_present') &&
-            adminPool.nic_tags_present.indexOf(nictag) != -1)) {
-
+            adminPool.nic_tags_present.indexOf(nictag) !== -1)) {
             adminFound = true;
             break;
         }


### PR DESCRIPTION
The following are the generated boot files with this change:

Expected new module file:

```
[root@47bff382-1cc8-455b-94d8-a939a37cd6a7 (coal:dhcpd0) /tftpboot]# cat bootfs/000c293f1084/etc/ppt_aliases
ppt "/pci@0,0/pci8086,151@1/display@0"
```

boot.ipxe:

```
[root@47bff382-1cc8-455b-94d8-a939a37cd6a7 (coal:dhcpd0) /tftpboot]# cat boot.ipxe.01000C293F1084
#!ipxe
kernel tftp://${next-server}/os/20191218T190857Z/platform/i86pc/kernel/amd64/unix -B hostname=uno,rabbitmq=guest:guest:10.99.99.20:5672,rabbitmq_dns=guest:guest:rabbitmq.coal.joyent.us:5672,admin_nic=00:0c:29:3f:10:84,external_nic=00:0c:29:3f:10:8e,console=text,text-mode="115200,8,n,1,-"
module tftp://${next-server}/os/20191218T190857Z/platform/i86pc/amd64/boot_archive type=rootfs name=ramdisk
module tftp://${next-server}/os/20191218T190857Z/platform/i86pc/amd64/boot_archive.hash type=hash name=ramdisk
module tftp://${next-server}/bootfs/000c293f1084/networking.json type=file name=networking.json
module tftp://${next-server}/bootfs/000c293f1084/networking.json.hash type=hash name=networking.json
module tftp://${next-server}/bootfs/000c293f1084/etc/ppt_aliases type=file name=etc/ppt_aliases
```

menu.lst:

```
[root@47bff382-1cc8-455b-94d8-a939a37cd6a7 (coal:dhcpd0) /tftpboot]# cat menu.lst.01000C293F1084
default 0
timeout 5
min_mem64 1024
variable os_console text
serial --unit=1 --speed=115200 --word=8 --parity=no --stop=1
terminal composite
color cyan/blue white/blue

title Live 64-bit
  kernel$ /os/20191218T190857Z/platform/i86pc/kernel/amd64/unix -B hostname=uno,rabbitmq=guest:guest:10.99.99.20:5672,rabbitmq_dns=guest:guest:rabbitmq.coal.joyent.us:5672,admin_nic=00:0c:29:3f:10:84,external_nic=00:0c:29:3f:10:8e,console=${os_console},${os_console}-mode="115200,8,n,1,-"
  module$ /os/20191218T190857Z/platform/i86pc/amd64/boot_archive type=rootfs name=ramdisk
  module$ /os/20191218T190857Z/platform/i86pc/amd64/boot_archive.hash type=hash name=ramdisk
  module$ /bootfs/000c293f1084/networking.json type=file name=networking.json
  module$ /bootfs/000c293f1084/networking.json.hash type=hash name=networking.json
  module$ /bootfs/000c293f1084/etc/ppt_aliases type=file name=etc/ppt_aliases

title Live 64-bit +kmdb
  kernel$ /os/20191218T190857Z/platform/i86pc/kernel/amd64/unix -d -k -B hostname=uno,rabbitmq=guest:guest:10.99.99.20:5672,rabbitmq_dns=guest:guest:rabbitmq.coal.joyent.us:5672,admin_nic=00:0c:29:3f:10:84,external_nic=00:0c:29:3f:10:8e,console=${os_console},${os_console}-mode="115200,8,n,1,-"
  module$ /os/20191218T190857Z/platform/i86pc/amd64/boot_archive type=rootfs name=ramdisk
  module$ /os/20191218T190857Z/platform/i86pc/amd64/boot_archive.hash type=hash name=ramdisk
  module$ /bootfs/000c293f1084/networking.json type=file name=networking.json
  module$ /bootfs/000c293f1084/networking.json.hash type=hash name=networking.json
  module$ /bootfs/000c293f1084/etc/ppt_aliases type=file name=etc/ppt_aliases

title Live 64-bit Rescue (no importing zpool)
  kernel$ /os/20191218T190857Z/platform/i86pc/kernel/amd64/unix -B hostname=uno,rabbitmq=guest:guest:10.99.99.20:5672,rabbitmq_dns=guest:guest:rabbitmq.coal.joyent.us:5672,admin_nic=00:0c:29:3f:10:84,external_nic=00:0c:29:3f:10:8e,noimport=true,console=${os_console},${os_console}-mode="115200,8,n,1,-"
  module$ /os/20191218T190857Z/platform/i86pc/amd64/boot_archive type=rootfs name=ramdisk
```